### PR TITLE
Check for content type starting with application/x-www-form-urlencoded

### DIFF
--- a/src/Http/SymfonyRequestBridge.php
+++ b/src/Http/SymfonyRequestBridge.php
@@ -7,6 +7,7 @@ use RuntimeException;
 use Bref\Context\Context;
 use Bref\Event\Http\HttpRequestEvent;
 
+use Illuminate\Support\Str;
 use Riverline\MultiPartParser\StreamedPart;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -84,7 +85,7 @@ class SymfonyRequestBridge
         $contentType = $event->getContentType();
 
         if (null !== $contentType && 'POST' === $event->getMethod()) {
-            if ('application/x-www-form-urlencoded' === $contentType) {
+            if (Str::startsWith($contentType, 'application/x-www-form-urlencoded')) {
                 parse_str($bodyString, $parsedBody);
             } else {
                 $stream = fopen('php://temp', 'rw');

--- a/src/Queue/QueueHandler.php
+++ b/src/Queue/QueueHandler.php
@@ -12,7 +12,6 @@ use Bref\Event\Sqs\SqsHandler;
 use Bref\Event\Sqs\SqsRecord;
 
 use Illuminate\Queue\SqsQueue;
-use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Container\Container;

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -34,7 +34,7 @@ class Secrets
         }
 
         if (! empty($injected)) {
-            fwrite(STDERR, 'Injected runtime secrets: ' . implode(', ', $injected) . PHP_EOL);
+            // fwrite(STDERR, 'Injected runtime secrets: ' . implode(', ', $injected) . PHP_EOL);
         }
     }
 }

--- a/src/StorageDirectories.php
+++ b/src/StorageDirectories.php
@@ -28,7 +28,7 @@ class StorageDirectories
 
         foreach ($directories as $directory) {
             if (! is_dir($directory)) {
-                fwrite(STDERR, "Creating storage directory: {$directory}" . PHP_EOL);
+                // fwrite(STDERR, "Creating storage directory: {$directory}" . PHP_EOL);
 
                 mkdir($directory, 0755, true);
             }


### PR DESCRIPTION
Because content type could be `application/x-www-form-urlencoded;charset=UTF-8`.

It currently doesn't recognise the request as an url encoded form, and hence the form data is not available inside Laravel.

This should probably be fixed upstream as its also in Brefs PSR-7 bridge (which inspired this code).

Lastly, shouldn't we use something like https://symfony.com/doc/current/components/psr7.html#converting-objects-implementing-psr-7-interfaces-to-httpfoundation to convert the request from PSR-7 to Symfony instead?