### PR TITLE
Resolve SSM parameters using lambda extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Resolve SSM parameters using lambda extension ([#29](https://github.com/cachewerk/bref-laravel-bridge/pull/29))
+
 ## [v0.3.0] - 2022-11-15
 ### Changed
 - Use Laravel-native queue handler ([#13](https://github.com/cachewerk/bref-laravel-bridge/pull/13))

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Additionally, you can use the [Parameters and Secrets Lambda extension](https://
 
 <details>
 <summary>Minimal serverless.yml example using Parameters and Secrets Lambda extension</summary>
+
 ```yml
 service: my-app
 
@@ -131,6 +132,7 @@ functions:
     events:
       - httpApi: "*"
 ```
+
 </details>
 
 Finally, deploy your app:

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -42,7 +42,7 @@ class Secrets
      *
      * @param  string  $path
      * @param  array  $parameters
-     * @return void
+     * @return array
      */
     protected static function resolveUsingLambdaExtension(string $path, array $parameters): array
     {
@@ -70,7 +70,7 @@ class Secrets
      *
      * @param  string  $path
      * @param  array  $parameters
-     * @return void
+     * @return array
      */
     protected static function resolveUsingAwsSdk(string $path, array $parameters): array
     {

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -4,7 +4,6 @@ namespace CacheWerk\BrefLaravelBridge;
 
 use Aws\Ssm\SsmClient;
 
-
 use Illuminate\Http\Client\Pool;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -3,10 +3,12 @@
 namespace CacheWerk\BrefLaravelBridge;
 
 use Aws\Ssm\SsmClient;
-use Illuminate\Http\Client\PendingRequest;
+
+
 use Illuminate\Http\Client\Pool;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Http\Client\PendingRequest;
 
 class Secrets
 {
@@ -37,9 +39,16 @@ class Secrets
         }
     }
 
+    /**
+     * Resolves secrets using Lambda extension.
+     *
+     * @param  string  $path
+     * @param  array  $parameters
+     * @return void
+     */
     protected static function resolveUsingLambdaExtension(string $path, array $parameters): array
     {
-        $httpFactory = new \Illuminate\Http\Client\Factory();
+        $httpFactory = new \Illuminate\Http\Client\Factory;
         $httpPool = new \Illuminate\Http\Client\Pool($httpFactory);
 
         foreach ($parameters as $secret) {
@@ -58,6 +67,13 @@ class Secrets
             ->toArray();
     }
 
+    /**
+     * Resolves secrets from AWS Systems Manager using SDK.
+     *
+     * @param  string  $path
+     * @param  array  $parameters
+     * @return void
+     */
     protected static function resolveUsingAwsSdk(string $path, array $parameters): array
     {
         $ssm = new SsmClient([

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -3,9 +3,14 @@
 namespace CacheWerk\BrefLaravelBridge;
 
 use Aws\Ssm\SsmClient;
+use Illuminate\Http\Client\Pool;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
 
 class Secrets
 {
+    protected const LAMDA_EXTENSION_BINARY_PATH = '/opt/extensions/AWSParametersAndSecretsLambdaExtension';
+
     /**
      * Inject AWS SSM parameters into environment.
      *
@@ -14,6 +19,43 @@ class Secrets
      * @return void
      */
     public static function injectIntoEnvironment(string $path, array $parameters)
+    {
+        $resolved = \file_exists(self::LAMDA_EXTENSION_BINARY_PATH)
+            ? self::resolveUsingLambdaExtension($path, $parameters)
+            : self::resolveUsingAwsSdk($path, $parameters);
+
+        $injected = [];
+
+        foreach ($resolved as $key => $value) {
+            $injected[] = isset($_ENV[$key]) ? "{$key} (overwritten)" : $key;
+            $_ENV[$key] = $value;
+        }
+
+        if (! empty($injected)) {
+            fwrite(STDERR, 'Injected runtime secrets: ' . implode(', ', $injected) . PHP_EOL);
+        }
+    }
+
+    protected static function resolveUsingLambdaExtension(string $path, array $parameters): array
+    {
+        $responses = Http::pool(
+            fn (Pool $pool) => collect($parameters)->map(
+                fn (string $secret) => $pool->as($secret)->withHeaders([
+                    'X-Aws-Parameters-Secrets-Token' => env('AWS_SESSION_TOKEN'),
+                ])->get('http://localhost:2773/systemsmanager/parameters/get', [
+                    'name' => $path . $secret,
+                    'withDecryption' => 'true',
+                ])
+            )
+        );
+
+        return collect($responses)
+            ->filter(fn (Response $response) => $response->ok())
+            ->map(fn (Response $response) => $response->json('Parameter.Value'))
+            ->toArray();
+    }
+
+    protected static function resolveUsingAwsSdk(string $path, array $parameters): array
     {
         $ssm = new SsmClient([
             'version' => 'latest',
@@ -25,16 +67,8 @@ class Secrets
             'WithDecryption' => true,
         ]);
 
-        $injected = [];
-
-        foreach ($response['Parameters'] ?? [] as $secret) {
-            $key = trim(strrchr($secret['Name'], '/'), '/');
-            $injected[] = isset($_ENV[$key]) ? "{$key} (overwritten)" : $key;
-            $_ENV[$key] = $secret['Value'];
-        }
-
-        if (! empty($injected)) {
-            fwrite(STDERR, 'Injected runtime secrets: ' . implode(', ', $injected) . PHP_EOL);
-        }
+        return collect($response['Parameters'] ?? [])
+            ->mapWithKeys(fn (array $secret) => [trim(strrchr($secret['Name'], '/'), '/') => $secret['Value']])
+            ->toArray();
     }
 }

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -3,6 +3,7 @@
 namespace CacheWerk\BrefLaravelBridge;
 
 use Aws\Ssm\SsmClient;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Pool;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
@@ -38,18 +39,20 @@ class Secrets
 
     protected static function resolveUsingLambdaExtension(string $path, array $parameters): array
     {
-        $responses = Http::pool(
-            fn (Pool $pool) => collect($parameters)->map(
-                fn (string $secret) => $pool->as($secret)->withHeaders([
-                    'X-Aws-Parameters-Secrets-Token' => env('AWS_SESSION_TOKEN'),
-                ])->get('http://localhost:2773/systemsmanager/parameters/get', [
-                    'name' => $path . $secret,
-                    'withDecryption' => 'true',
-                ])
-            )
-        );
+        $httpFactory = new \Illuminate\Http\Client\Factory();
+        $httpPool = new \Illuminate\Http\Client\Pool($httpFactory);
 
-        return collect($responses)
+        foreach ($parameters as $secret) {
+            $httpPool->as($secret)->withHeaders([
+                'X-Aws-Parameters-Secrets-Token' => env('AWS_SESSION_TOKEN'),
+            ])->get('http://localhost:2773/systemsmanager/parameters/get', [
+                'name' => $path . $secret,
+                'withDecryption' => 'true',
+            ]);
+        }
+
+        return collect($httpPool->getRequests())
+            ->map(fn (PendingRequest $request) => $request->getPromise()->wait())
             ->filter(fn (Response $response) => $response->ok())
             ->map(fn (Response $response) => $response->json('Parameter.Value'))
             ->toArray();

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -12,8 +12,6 @@ use Illuminate\Http\Client\PendingRequest;
 
 class Secrets
 {
-    protected const LAMDA_EXTENSION_BINARY_PATH = '/opt/extensions/AWSParametersAndSecretsLambdaExtension';
-
     /**
      * Inject AWS SSM parameters into environment.
      *
@@ -23,13 +21,13 @@ class Secrets
      */
     public static function injectIntoEnvironment(string $path, array $parameters)
     {
-        $resolved = \file_exists(self::LAMDA_EXTENSION_BINARY_PATH)
+        $parameters = \file_exists('/opt/extensions/AWSParametersAndSecretsLambdaExtension')
             ? self::resolveUsingLambdaExtension($path, $parameters)
             : self::resolveUsingAwsSdk($path, $parameters);
 
         $injected = [];
 
-        foreach ($resolved as $key => $value) {
+        foreach ($parameters as $key => $value) {
             $injected[] = isset($_ENV[$key]) ? "{$key} (overwritten)" : $key;
             $_ENV[$key] = $value;
         }


### PR DESCRIPTION
Todo:
- [x] Add docs
- [x] Update changelog

---

How to get it to work:
- Add the [required layer](https://docs.aws.amazon.com/systems-manager/latest/userguide/ps-integration-lambda-extensions.html#ps-integration-lambda-extensions-add) to your function(s)
- Ensure your functions have access to `ssm:GetParameter`
- Add `APP_SSM_PREFIX` and `APP_SSM_PARAMETERS` as usual

Minimal serverless.yml example:
```yml
service: my-app

provider:
  name: aws
  region: eu-central-1
  stage: staging
  runtime: provided.al2
  environment:
    APP_SSM_PREFIX: /${self:service}-${sls:stage}/
    APP_SSM_PARAMETERS: "APP_KEY, WORKERLESS_LICENSE_KEY, TEST_NON_EXISTING_KEY"
  iam:
    role:
      statements:
        - Effect: Allow
          Resource: arn:aws:ssm:${aws:region}:${aws:accountId}:parameter/${self:service}-${sls:stage}/*
          Action: [ ssm:GetParameter, ssm:GetParameters ] # singular for extension, plural for sdk

plugins:
  - ./vendor/bref/bref

functions:
  web:
    handler: php/runtime.php
    environment:
      APP_RUNTIME: octane
      BREF_LOOP_MAX: 250
    layers:
      - ${bref:layer.php-81}
      - arn:aws:lambda:eu-central-1:187925254637:layer:AWS-Parameters-and-Secrets-Lambda-Extension:2
    events:
      - httpApi: "*"
```