### PR TITLE
Do not enable the S3 filesystem by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ functions:
 
 If you want all CloudWatch log entries to be JSON objects (for example because you want to ingest those logs in other systems), you can edit `config/logging.php` to set the `channels.stderr.formatter` to `Monolog\Formatter\JsonFormatter::class`.
 
+### File storage
+
+When running on Lambda, the filesystem is temporary and not shared between instances. If you want to use the Filesystem API, you will need to use the `s3` adapter to store files on AWS S3.
+
+To do this, set `FILESYSTEM_DISK: s3` either in `serverless.yml` or your production `.env` file and configure the S3 bucket to use in `config/filesystems.php`.
+
 ## Usage
 
 ### Artisan Console

--- a/examples/getting-started/serverless.yml
+++ b/examples/getting-started/serverless.yml
@@ -32,6 +32,9 @@ provider:
     SQS_QUEUE: ${self:service}-${sls:stage}
     DYNAMODB_CACHE_TABLE: ${self:service}-${sls:stage}-cache
     MAINTENANCE_MODE: ${param:maintenance, null}
+    # Use S3 for filesystem storage
+    FILESYSTEM_DISK: s3
+    AWS_BUCKET: !Ref StorageBucket
   iam:
     role:
       statements:
@@ -44,6 +47,12 @@ provider:
         - Effect: Allow
           Resource: arn:aws:ssm:${aws:region}:${aws:accountId}:parameter/${self:service}-${sls:stage}/*
           Action: [ssm:GetParameters]
+        # Allow Lambda to read and write files in the S3 storage bucket
+        - Effect: Allow
+          Action: s3:*
+          Resource:
+            - !Sub '${StorageBucket.Arn}' # the storage bucket
+            - !Sub '${StorageBucket.Arn}/*' # and everything inside
 
 plugins:
   - ./vendor/bref/bref
@@ -133,3 +142,7 @@ resources:
       Properties:
         QueueName: ${self:service}-${sls:stage}
         VisibilityTimeout: 70
+    StorageBucket:
+      Type: AWS::S3::Bucket
+      Properties:
+        Description: Storage bucket for the Laravel application

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -139,10 +139,6 @@ class BrefServiceProvider extends ServiceProvider
             Config::set('session.driver', 'cookie');
         }
 
-        if (Config::get('filesystems.default') === 'local') {
-            Config::set('filesystems.default', 's3');
-        }
-
         if (Config::get('logging.default') === 'stack') {
             Config::set('logging.default', 'stderr');
         }


### PR DESCRIPTION
This is a follow-up on https://github.com/brefphp/laravel-bridge/discussions/79#discussioncomment-4177652

Setting the S3 filesystem by default could be confusing because it won't work (the S3 bucket needs to be created and configured).