### PR TITLE
Make optional logging as JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.0.0]
+### Breaking Changes
+- Logs are now written in plain text by default instead of JSON. To enable JSON logs, set `logs_as_json` to `true` in `config/bref.php`.
+
 ## [Unreleased]
 ## [v0.3.0] - 2022-11-15
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v2.0.0]
 ### Breaking Changes
-- Logs are now written in plain text by default instead of JSON. To enable JSON logs, set `logs_as_json` to `true` in `config/bref.php`.
+- Logs are now written in plain text by default instead of JSON. To enable JSON logs, set `channels.stderr.formatter` to `Monolog\Formatter\JsonFormatter::class` in `config/logging.php`.
 
 ## [Unreleased]
 ## [v0.3.0] - 2022-11-15

--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ functions:
       OCTANE_PERSIST_DATABASE_SESSIONS: 1
 ```
 
+### JSON logs
+
+If you want all CloudWatch log entries to be JSON objects (for example because you want to ingest those logs in other systems), you can edit `config/logging.php` to set the `channels.stderr.formatter` to `Monolog\Formatter\JsonFormatter::class`.
+
 ## Usage
 
 ### Artisan Console

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "illuminate/queue": "^8.0 || ^9.0",
         "illuminate/support": "^8.0 || ^9.0",
         "laravel/octane": "^1.2",
-        "monolog/monolog": "^2.0",
         "riverline/multipart-parser": "^2.0"
     },
     "require-dev": {

--- a/config/bref.php
+++ b/config/bref.php
@@ -30,4 +30,16 @@ return [
 
     'request_context' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Write logs as JSON
+    |--------------------------------------------------------------------------
+    |
+    | By default, logs are written to CloudWatch as plain text.
+    | If you prefer, you can have them logged as JSON objects instead.
+    |
+    */
+
+    'logs_as_json' => false,
+
 ];

--- a/config/bref.php
+++ b/config/bref.php
@@ -30,16 +30,4 @@ return [
 
     'request_context' => false,
 
-    /*
-    |--------------------------------------------------------------------------
-    | Write logs as JSON
-    |--------------------------------------------------------------------------
-    |
-    | By default, logs are written to CloudWatch as plain text.
-    | If you prefer, you can have them logged as JSON objects instead.
-    |
-    */
-
-    'logs_as_json' => false,
-
 ];

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -2,8 +2,6 @@
 
 namespace CacheWerk\BrefLaravelBridge;
 
-use Monolog\Formatter\JsonFormatter;
-
 use Illuminate\Log\LogManager;
 
 use Illuminate\Support\Facades\Config;
@@ -39,10 +37,6 @@ class BrefServiceProvider extends ServiceProvider
         $this->fixDefaultConfiguration();
 
         Config::set('app.mix_url', Config::get('app.asset_url'));
-
-        if (Config::get('bref.logs_as_json')) {
-            Config::set('logging.channels.stderr.formatter', JsonFormatter::class);
-        }
 
         Config::set('trustedproxy.proxies', ['0.0.0.0/0', '2000:0:0:0:0:0:0:0/3']);
 

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -40,7 +40,9 @@ class BrefServiceProvider extends ServiceProvider
 
         Config::set('app.mix_url', Config::get('app.asset_url'));
 
-        Config::set('logging.channels.stderr.formatter', JsonFormatter::class);
+        if (Config::get('bref.logs_as_json')) {
+            Config::set('logging.channels.stderr.formatter', JsonFormatter::class);
+        }
 
         Config::set('trustedproxy.proxies', ['0.0.0.0/0', '2000:0:0:0:0:0:0:0/3']);
 


### PR DESCRIPTION
Follow-up on https://github.com/brefphp/laravel-bridge/discussions/79#discussioncomment-4177635

AFAIK, most tools beginners might start with to view logs (AWS Console, CLI tools like `sls logs`, Bref Dashboard, etc.) will be more readable with plain text logs instead of a whole JSON object.

Logging to JSON could be useful later to query logs, or have them parsed by more advanced tools (maybe ELK I have in mind, but I might be wrong), so I reckon it might be better not making JSON the default option.