### PR TITLE
Improve logs and error handling on directory creation

### DIFF
--- a/src/StorageDirectories.php
+++ b/src/StorageDirectories.php
@@ -2,6 +2,8 @@
 
 namespace CacheWerk\BrefLaravelBridge;
 
+use RuntimeException;
+
 class StorageDirectories
 {
     /**
@@ -27,13 +29,14 @@ class StorageDirectories
         ];
 
         $directories = array_filter($directories, static fn ($directory) => ! is_dir($directory));
-        if (count($directories) > 0) {
+
+        if (count($directories)) {
             fwrite(STDERR, 'Creating storage directories: ' . implode(', ', $directories) . PHP_EOL);
         }
 
         foreach ($directories as $directory) {
-            if (!mkdir($directory, 0755, true) && !is_dir($directory)) {
-                throw new \RuntimeException(sprintf('Directory "%s" could not created', $directory));
+            if (! mkdir($directory, 0755, true) && ! is_dir($directory)) {
+                throw new RuntimeException("Directory {$directory} could not be created");
             }
         }
     }

--- a/src/StorageDirectories.php
+++ b/src/StorageDirectories.php
@@ -26,11 +26,14 @@ class StorageDirectories
             self::Path . '/framework/views',
         ];
 
-        foreach ($directories as $directory) {
-            if (! is_dir($directory)) {
-                fwrite(STDERR, "Creating storage directory: {$directory}" . PHP_EOL);
+        $directories = array_filter($directories, static fn ($directory) => ! is_dir($directory));
+        if (count($directories) > 0) {
+            fwrite(STDERR, 'Creating storage directories: ' . implode(', ', $directories) . PHP_EOL);
+        }
 
-                mkdir($directory, 0755, true);
+        foreach ($directories as $directory) {
+            if (!mkdir($directory, 0755, true) && !is_dir($directory)) {
+                throw new \RuntimeException(sprintf('Directory "%s" could not created', $directory));
             }
         }
     }


### PR DESCRIPTION
Very small changes that I did while working on other things:

- collapse logs for directory creations, because it will be kind of repetitive once you have seen it once
- ensure the direction creation was successful

Before:
<img width="562" alt="Screen-000978" src="https://user-images.githubusercontent.com/720328/218481949-93559ef5-d384-418f-8222-a36c571295ee.png">

After:

<img width="1139" alt="Screen-000979" src="https://user-images.githubusercontent.com/720328/218481918-348dcebe-4761-4e94-8584-67dd71766989.png">
