### PR TITLE
Shutdown PHP after a queue timeout

### DIFF
--- a/src/Queue/Worker.php
+++ b/src/Queue/Worker.php
@@ -27,6 +27,9 @@ class Worker extends LaravelWorker
                 $job,
                 $this->maxAttemptsExceededException($job),
             );
+
+            // exit so that PHP will shutdown and close DB connections etc.
+            exit(1);
         });
 
         pcntl_alarm(


### PR DESCRIPTION
Fixes  #24

This will shutdown PHP (and with it, the lambda container instance) so that database connections and other sockets/handles will be closed.